### PR TITLE
Include libsbp properly

### DIFF
--- a/swiftnav_piksi/CMakeLists.txt
+++ b/swiftnav_piksi/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 ## System dependencies are found with CMake's conventions
 #find_package(swiftnav REQUIRED)
-find_library(SBP sbp)
+find_package(Sbp 2.2.0 REQUIRED)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and scripts declared therein get installed
@@ -54,7 +54,7 @@ catkin_package(
    INCLUDE_DIRS include
    LIBRARIES piksi piksi_driver
    CATKIN_DEPENDS diagnostic_updater roscpp sensor_msgs std_srvs
-#  DEPENDS system_lib
+#  DEPENDS system_lib ${SBP_LIBRARIES}
 )
 
 ###########
@@ -63,6 +63,7 @@ catkin_package(
 
 ## Specify additional locations of header files
 include_directories(include
+  ${SBP_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 
@@ -83,10 +84,10 @@ add_executable(piksitest src/piksi.c)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(piksi
-  ${SBP}
+  ${SBP_LIBRARIES}
 )
 target_link_libraries(piksitest
-  ${SBP}
+  ${SBP_LIBRARIES}
 )
 target_link_libraries(piksi_driver
   sbp

--- a/swiftnav_piksi/CMakeLists.txt
+++ b/swiftnav_piksi/CMakeLists.txt
@@ -54,7 +54,7 @@ catkin_package(
    INCLUDE_DIRS include
    LIBRARIES piksi piksi_driver
    CATKIN_DEPENDS diagnostic_updater roscpp sensor_msgs std_srvs
-#  DEPENDS system_lib ${SBP_LIBRARIES}
+   DEPENDS SBP
 )
 
 ###########

--- a/swiftnav_piksi/package.xml
+++ b/swiftnav_piksi/package.xml
@@ -18,13 +18,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>diagnostic_updater</build_depend>
-  <build_depend>libswiftnav</build_depend>
+  <build_depend>libsbp-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>swiftnav_piksi_msgs</build_depend>
   <run_depend>diagnostic_updater</run_depend>
-  <run_depend>libswiftnav</run_depend>
+  <run_depend>libsbp-dev</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_srvs</run_depend>

--- a/swiftnav_piksi/src/piksi_driver.cpp
+++ b/swiftnav_piksi/src/piksi_driver.cpp
@@ -180,7 +180,7 @@ namespace swiftnav_piksi
 		time_msg->header.stamp = ros::Time::now( );
 
 		time_msg->time_of_week = time.tow;
-		time_msg->nano = time.ns;
+		time_msg->nano = time.ns_residual;
 		time_msg->time_source = (time.flags & 0x0007);
 
 		driver->time_pub.publish( time_msg );


### PR DESCRIPTION
This updates swiftnav_piksi's package.xml file to look up libsbp-dev properly (using our internal Debian server) and modifies its CMakeLists.txt to use cmake to look up its include and library paths.

In addition, a member variable in the `msg_gps_time_t` struct changed in libsbp 2.2.0, so this updates a references to that class so that it will compile against it properly.

Fixes #5

@evenator @duster3